### PR TITLE
Fixing ship issue

### DIFF
--- a/lib/game.rb
+++ b/lib/game.rb
@@ -3,8 +3,7 @@ class Game
   def initialize
     @player_board = Board.new
     @computer_board = Board.new
-    @possible_ships = {cruiser: Ship.new("Cruiser", 3),
-                      submarine: Ship.new("Submarine", 2)}
+    @possible_ships = [["Cruiser", 3],["Submarine", 2]]
     @last_turn = {computer_shot: nil,
                   computer_result: nil,
                   player_shot: nil,
@@ -13,5 +12,11 @@ class Game
 
   def game_over?
     [@player_board, @computer_board].any? {|board| board.all_ships_sunk?}
+  end
+
+  def create_ships
+    @possible_ships.map do |ship_name, ship_length|
+      Ship.new(ship_name, ship_length)
+    end
   end
 end

--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -27,7 +27,7 @@ class Runner
   def setup
     @game = Game.new
     # place computer ships
-    @game.possible_ships.each do |ship_name, ship_object|
+    @game.create_ships.each do |ship_object|
       @game.computer_board.place_ship_randomly(ship_object)
     end
 
@@ -36,10 +36,10 @@ class Runner
     puts "The Cruiser is three units long, and the Submarine is two units long."
 
     # loop to prompt user to place all ships
-    @game.possible_ships.each do |ship_name, ship_object|
-      until @game.player_board.cells.values.any? {|cell| cell.ship == ship_object}
+    @game.create_ships.each do |ship_object|
+      until @game.player_board.all_ships.include?(ship_object)
         puts @game.player_board.render(true)
-        puts "Enter the coordinates for the #{@game.possible_ships[ship_name].name}:"
+        puts "Enter the coordinates for the #{ship_object.name}:"
         user_input = gets.chomp.upcase.split(' ')
         if @game.player_board.valid_placement?(ship_object, user_input)
           @game.player_board.place(ship_object, user_input)
@@ -53,6 +53,7 @@ class Runner
 
   def game_turns
     until @game.game_over?
+      require "pry"; binding.pry
     end
   end
 end

--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -53,7 +53,6 @@ class Runner
 
   def game_turns
     until @game.game_over?
-      require "pry"; binding.pry
     end
   end
 end


### PR DESCRIPTION
Realized we had a problem with the way we handled ship objects; because I didn't understand at the time that objects are not _copied_ when they are placed in variables, we were placing the same two ships on both boards, so that when one was hit, both it and the one on the other board would be hit--because they are the same ship.

Fixed by creating a new method which creates two new ships based on a template (which is what I think I really intended the @possible_ships to be for).